### PR TITLE
Version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `AssemblyLoaderImporter` to select `debug` or `release` version of `Isolator.Template` based on `EnableDebug` setting.
 - Update `Build` to release in `Nuget`.
 - Create `Isolator.Fody.Tests` project to test `Isolator.ConsoleApp` and `Isolator.Fody` functionality.
+- Update `Configuration` to use `LoadAtModuleInit` and force `Attach` to create default `AssemblyLoadContext` at module init.
 
 [vNext]: ../../compare/1.0.0...HEAD
 [1.0.0]: ../../compare/1.0.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.10</Version>
+    <Version>1.0.0-rc.11</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.12</Version>
+    <Version>1.0.0-rc.13</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.11</Version>
+    <Version>1.0.0-rc.12</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.6</Version>
+    <Version>1.0.0-rc.7</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.13</Version>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.8</Version>
+    <Version>1.0.0-rc.9</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.7</Version>
+    <Version>1.0.0-rc.8</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-rc.9</Version>
+    <Version>1.0.0-rc.10</Version>
   </PropertyGroup>
 </Project>

--- a/Isolator.ConsoleApp/Isolator.ConsoleApp.csproj
+++ b/Isolator.ConsoleApp/Isolator.ConsoleApp.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup>
     <WeaverConfiguration>
       <Weavers>
-        <Isolator InterfaceNames="IsolatorInterface" EnableDebug="false" />
+        <Isolator InterfaceNames="IsolatorInterface" />
       </Weavers>
     </WeaverConfiguration>
   </PropertyGroup>

--- a/Isolator.Fody.Tests/Tests.cs
+++ b/Isolator.Fody.Tests/Tests.cs
@@ -9,5 +9,29 @@ namespace Isolator.Fody.Tests
         {
             Program.Main(Array.Empty<string>());
         }
+
+        [Test]
+        public void AssemblyLoader_Exists()
+        {
+            var type = typeof(Program).Assembly.GetType("Isolator.AssemblyLoader");
+            Assert.NotNull(type);
+        }
+
+        [Test]
+        public void AssemblyLoader_Method_Log_Exists()
+        {
+            var type = typeof(Program).Assembly.GetType("Isolator.AssemblyLoader");
+            Assert.NotNull(type);
+
+            var bindingFlags = System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static;
+            var method = type.GetMethod("Log", bindingFlags);
+
+            // The 'Log' method is only included in DEBUG builds or when `EnableDebug` is set to true.
+#if DEBUG
+            Assert.NotNull(method);
+#else
+            Assert.Null(method);
+#endif
+        }
     }
 }

--- a/Isolator.Fody/AssemblyLoader/AssemblyLoaderImporter.cs
+++ b/Isolator.Fody/AssemblyLoader/AssemblyLoaderImporter.cs
@@ -13,15 +13,6 @@ public partial class ModuleWeaver
     private TypeDefinition _sourceType;
     private TypeDefinition _commonType;
     private MethodDefinition _attachMethod;
-    //private MethodDefinition _loaderCctor;
-    //private bool _hasUnmanaged;
-    //private FieldDefinition _assemblyNamesField;
-    //private FieldDefinition _symbolNamesField;
-    //private FieldDefinition _preloadListField;
-    //private FieldDefinition _preloadWinX86ListField;
-    //private FieldDefinition _preloadWinX64ListField;
-    //private FieldDefinition _preloadWinArm64ListField;
-    //private FieldDefinition _checksumsField;
 
     private const string ModuleName = "Isolator";
 
@@ -30,6 +21,8 @@ public partial class ModuleWeaver
     /// </summary>
     private void ImportAssemblyLoader(bool debugTemplate = false)
     {
+        FindMsCoreReferences();
+
         var readerParameters = new ReaderParameters
         {
             AssemblyResolver = new NetStandardAssemblyResolver(this),
@@ -89,13 +82,6 @@ public partial class ModuleWeaver
             // Copy type + nested types
             CopyType(_targetType, _sourceType, true, true);
             _attachMethod = _targetType.Methods.SingleOrDefault(_ => _.Name == "Attach");
-
-            //// Copy type + nested types
-            //CopyType(_targetType, _sourceType, true, false);
-
-            //CopyMethod(_targetType, _sourceType.Methods.Single(_ => _.Name == "ResolveAssembly"));
-            //_loaderCctor = CopyMethod(_targetType, _sourceType.Methods.Single(_ => _.IsConstructor && _.IsStatic));
-            //_attachMethod = CopyMethod(_targetType, _sourceType.Methods.Single(_ => _.Name == "Attach"));
         }
     }
 
@@ -160,41 +146,6 @@ public partial class ModuleWeaver
         {
             var newField = new FieldDefinition(field.Name, field.Attributes, Resolve(field.FieldType));
             targetType.Fields.Add(newField);
-
-            //if (field.Name == "assemblyNames")
-            //{
-            //    _assemblyNamesField = newField;
-            //}
-
-            //if (field.Name == "symbolNames")
-            //{
-            //    _symbolNamesField = newField;
-            //}
-
-            //if (field.Name == "preloadList")
-            //{
-            //    _preloadListField = newField;
-            //}
-
-            //if (field.Name == "preloadWinX86List")
-            //{
-            //    _preloadWinX86ListField = newField;
-            //}
-
-            //if (field.Name == "preloadWinX64List")
-            //{
-            //    _preloadWinX64ListField = newField;
-            //}
-
-            //if (field.Name == "preloadWinArm64List")
-            //{
-            //    _preloadWinArm64ListField = newField;
-            //}
-
-            //if (field.Name == "checksums")
-            //{
-            //    _checksumsField = newField;
-            //}
         }
     }
 
@@ -376,11 +327,6 @@ public partial class ModuleWeaver
 
     private Instruction CloneInstruction(TypeDefinition targetType, Instruction instruction)
     {
-        //if (instruction.OpCode == OpCodes.Ldstr && (string)instruction.Operand == "To be replaced at compile time")
-        //{
-        //    return Instruction.Create(OpCodes.Ldstr, _resourcesHash);
-        //}
-
         var newInstruction = (Instruction)_instructionConstructorInfo.Invoke(new[] { instruction.OpCode, instruction.Operand });
         newInstruction.Operand = Import(targetType, instruction.Operand);
         return newInstruction;

--- a/Isolator.Fody/AssemblyLoader/CallAttach.cs
+++ b/Isolator.Fody/AssemblyLoader/CallAttach.cs
@@ -14,7 +14,7 @@ public partial class ModuleWeaver
             return;
         }
 
-        var initialized = FindInitializeCalls();
+        //var initialized = FindInitializeCalls();
 
         if (loadAtModuleInit)
         {

--- a/Isolator.Fody/AssemblyLoader/MsCoreReferenceFinder.cs
+++ b/Isolator.Fody/AssemblyLoader/MsCoreReferenceFinder.cs
@@ -4,20 +4,13 @@ using Mono.Cecil;
 public partial class ModuleWeaver
 {
     private MethodReference _compilerGeneratedAttributeCtor;
-    private MethodReference _dictionaryOfStringOfStringAdd;
-    private MethodReference _listOfStringAdd;
 
     private void FindMsCoreReferences()
     {
-        var dictionary = FindTypeDefinition("System.Collections.Generic.Dictionary`2");
-        var dictionaryOfStringOfString = ModuleDefinition.ImportReference(dictionary);
-        _dictionaryOfStringOfStringAdd = ModuleDefinition.ImportReference(dictionaryOfStringOfString.Resolve().Methods.First(_ => _.Name == "Add"))
-            .MakeHostInstanceGeneric(TypeSystem.StringReference, TypeSystem.StringReference);
-
-        var list = FindTypeDefinition("System.Collections.Generic.List`1");
-        var listOfString = ModuleDefinition.ImportReference(list);
-        _listOfStringAdd = ModuleDefinition.ImportReference(listOfString.Resolve().Methods.First(_ => _.Name == "Add"))
-            .MakeHostInstanceGeneric(TypeSystem.StringReference);
+        if (_compilerGeneratedAttributeCtor != null)
+        {
+            return;
+        }
 
         var compilerGeneratedAttribute = FindTypeDefinition("System.Runtime.CompilerServices.CompilerGeneratedAttribute");
         _compilerGeneratedAttributeCtor = ModuleDefinition.ImportReference(compilerGeneratedAttribute.Methods.First(_ => _.IsConstructor));

--- a/Isolator.Fody/Configuration.cs
+++ b/Isolator.Fody/Configuration.cs
@@ -24,6 +24,9 @@ public class Configuration
         SkipIsolator = false;
         SkipIsolator = ReadBool(config, nameof(SkipIsolator), SkipIsolator);
 
+        LoadAtModuleInit = true;
+        LoadAtModuleInit = ReadBool(config, nameof(LoadAtModuleInit), LoadAtModuleInit);
+
         EnableCloneMethods = true;
         EnableCloneMethods = ReadBool(config, nameof(EnableCloneMethods), EnableCloneMethods);
 
@@ -31,6 +34,7 @@ public class Configuration
         EnableWriteBackRefOutParameters = ReadBool(config, nameof(EnableWriteBackRefOutParameters), EnableWriteBackRefOutParameters);
     }
 
+    public bool LoadAtModuleInit { get; }
     public bool SkipIsolator { get; }
     public bool EnableDebug { get; }
     public bool EnableCloneMethods { get; }

--- a/Isolator.Fody/Isolator.Fody.xcf
+++ b/Isolator.Fody/Isolator.Fody.xcf
@@ -37,6 +37,11 @@
       <xs:documentation>Skip the isolation process.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="LoadAtModuleInit" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Enable loading default context at module initialization.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
   <xs:attribute name="EnableCloneMethods" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>Enable cloning methods.</xs:documentation>

--- a/Isolator.Fody/IsolatorExecute.CloneMethod.cs
+++ b/Isolator.Fody/IsolatorExecute.CloneMethod.cs
@@ -15,6 +15,8 @@ public partial class ModuleWeaver
         var cloned = CloneMethodSignature(method, (prefix + method.Name).Replace(".", string.Empty));
         CloneMethodBody(method, cloned);
 
+        WriteInfo($"Cloning method: {method.FullName} to {cloned.FullName}");
+
         // 1.a Mark as [CompilerGenerated]
         AddCompilerGeneratedAttribute(cloned);
 

--- a/Isolator.Fody/IsolatorExecute.ContextName.cs
+++ b/Isolator.Fody/IsolatorExecute.ContextName.cs
@@ -17,9 +17,10 @@ public partial class ModuleWeaver
         {
             var contextNameValue = isolatorCustomAttribute?.ConstructorArguments[0].Value as string;
             InjectMethodWithStringParameter(method, _setContextName, contextNameValue);
+
+            WriteInfo($"Injected SetContextName with value: {contextNameValue} into method: {method.FullName}");
         }
     }
-
 
     private void FindContextNameMethod(string contextName)
     {

--- a/Isolator.Fody/IsolatorExecute.cs
+++ b/Isolator.Fody/IsolatorExecute.cs
@@ -38,11 +38,15 @@ public partial class ModuleWeaver
             // Add [CompilerGenerated] attribute to show the class is modified
             AddCompilerGeneratedAttribute(type);
 
+            WriteInfo($"Isolating Type: {type.FullName}");
+
             var index = 1;
             foreach (var method in type.Methods.OrderByDescending(e => e.IsConstructor).ToArray())
             {
                 if (!method.HasBody)
                     continue;
+
+                WriteInfo($"Isolating Method: {method.FullName}");
 
                 // Add [CompilerGenerated] attribute to show the method is modified
                 AddCompilerGeneratedAttribute(method);

--- a/Isolator.Fody/ModuleWeaver.cs
+++ b/Isolator.Fody/ModuleWeaver.cs
@@ -17,7 +17,7 @@ public sealed partial class ModuleWeaver : BaseModuleWeaver
         ImportAssemblyLoader(config.EnableDebug);
 
         FindContextNameMethod(config.ContextName);
-        // CallAttach();
+        CallAttach(config.LoadAtModuleInit);
 
         IsolatorExecute();
     }

--- a/Isolator.Fody/ModuleWeaver.cs
+++ b/Isolator.Fody/ModuleWeaver.cs
@@ -14,7 +14,6 @@ public sealed partial class ModuleWeaver : BaseModuleWeaver
 
         WriteInfo($"{GetType().Assembly.GetName().Name} v{GetType().Assembly.GetVersion()}");
 
-        FindMsCoreReferences();
         ImportAssemblyLoader(config.EnableDebug);
 
         FindContextNameMethod(config.ContextName);

--- a/Isolator.Template/ILTemplate.cs
+++ b/Isolator.Template/ILTemplate.cs
@@ -219,10 +219,11 @@ internal static class ILTemplate
 
     internal static void Attach()
     {
-        if (IsDefault()) return;
-        var assembly = Assembly.GetExecutingAssembly();
-        var context = AssemblyLoadContext.GetLoadContext(assembly);
-        Common.Log("[{0}] Context.Attach \t '{1}'", context.GetContextNumber(), context.Name);
+        if (IsDefault())
+        {
+            var context = GetContext();
+            Common.Log("[{0}] Context.Attach \t '{1}'", context.GetContextNumber(), context.Name);
+        }
     }
 
     internal class IsolatorAssemblyLoadContext : AssemblyLoadContext

--- a/Isolator.Template/ILTemplate.cs
+++ b/Isolator.Template/ILTemplate.cs
@@ -128,7 +128,7 @@ internal static class ILTemplate
                     {
                         ContextInvokeMethod(context, nameof(IsolatorAssemblyLoadContext.AddResolver), location);
                         _contextTable.Add(contextName, context);
-                        Common.Log("[{0}] Context.AddResolver \t '{1}'", context.GetContextNumber(), contextName);
+                        Common.Log("[{0}] Context.AddResolver \t '{1}' \t {2}", context.GetContextNumber(), contextName, location);
                         return context;
                     }
                     catch (Exception ex) { Common.Log("[{0}] Context.AddResolver.Exception \t '{1}'", context.GetContextNumber(), ex); }
@@ -139,7 +139,7 @@ internal static class ILTemplate
                 context?.Unloading += Unloading;
 
                 _contextTable.Add(contextName, context);
-                Common.Log("[{0}] Context.CreateInstance \t '{1}'", context.GetContextNumber(), contextName);
+                Common.Log("[{0}] Context.CreateInstance \t '{1}' \t {2}", context.GetContextNumber(), contextName, location);
                 return context;
             }
         }
@@ -222,7 +222,7 @@ internal static class ILTemplate
         if (IsDefault())
         {
             var context = GetContext();
-            Common.Log("[{0}] Context.Attach \t '{1}'", context.GetContextNumber(), context.Name);
+            Common.Log("[{0}] Context.AttachModule \t '{1}' \t {2}", context.GetContextNumber(), context.Name, Assembly.GetExecutingAssembly());
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ Disable the isolator process without the need to remove the weaver from the proj
 
 *This force the `[Isolator]` to be removed, and the class is not isolated.*
 
+### LoadAtModuleInit
+
+Indicates whether to load the `AssemblyLoadContext` at module initialization. When enabled, the context will be created and attached when the module is initialized.
+
+*Defaults to `true`*
+```xml
+<Isolator LoadAtModuleInit='false' />
+```
+
 ### EnableCloneMethods
 
 Indicates whether to clone methods that are called internally within the isolated class to ensure they also run in the isolated context.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ As an element with items delimited by a newline.
 Or as an attribute with items delimited by a pipe `|`.
 
 ```xml
-<Isolator InterfaceNames="IExternalApplication|IExternalDBApplication|IExternalCommand" />
+<Isolator InterfaceNames='IExternalApplication|IExternalDBApplication|IExternalCommand' />
 ```
 
 ## Debug Configuration Options
@@ -217,7 +217,7 @@ Indicates whether to clone methods that are called internally within the isolate
 *Defaults to `true`*
 
 ```xml
-<Isolator EnableCloneMethods='true' />
+<Isolator EnableCloneMethods='false' />
 ```
 
 ### EnableWriteBackRefOutParameters
@@ -227,7 +227,7 @@ Indicates whether to write back the values of `ref` and `out` parameters to the 
 *Defaults to `true`*
 
 ```xml
-<Isolator EnableWriteBackRefOutParameters='true' />
+<Isolator EnableWriteBackRefOutParameters='false' />
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ Inside your project file, add the following lines to reference the `Isolator.Fod
 
 ```xml
 <ItemGroup>
-	<PackageReference Include="Isolator.Fody" Version="*" IncludeAssets="build; compile" PrivateAssets="all" />
+  <PackageReference Include="Isolator.Fody" Version="*" IncludeAssets="build; compile" PrivateAssets="all" />
 </ItemGroup>
 ```
 
 Then, add the following configuration to enable the weaver:
 ```xml
 <PropertyGroup>
-	<WeaverConfiguration>
-		<Weavers>
-			<Isolator />
-		</Weavers>
-	</WeaverConfiguration>
+  <WeaverConfiguration>
+    <Weavers>
+      <Isolator />
+    </Weavers>
+  </WeaverConfiguration>
 </PropertyGroup>
 ```
 
@@ -36,14 +36,14 @@ Next, mark the classes you want to isolate with the `[Isolator]` attribute:
 [Isolator]
 public class MyIsolatedClass
 {
-	public MyIsolatedClass()
-	{
-		Console.WriteLine("Constructor implementation");
-	}
-	public void MyMethod()
-	{
-		Console.WriteLine("Method implementation");
-	}
+  public MyIsolatedClass()
+  {
+    Console.WriteLine("Constructor implementation");
+  }
+  public void MyMethod()
+  {
+    Console.WriteLine("Method implementation");
+  }
 }
 ```
 
@@ -55,39 +55,39 @@ When you build your project, the weaver will modify the IL code of the marked cl
 [CompilerGenerated]
 public class MyIsolatedClass
 {
-	[CompilerGenerated]
-	public MyIsolatedClass()
-	{
-		if (AssemblyLoader.IsDefault())
-		{
-			object obj = AssemblyLoader.CreateInstance(this, new object[0]);
-			return;
-		}
-		_isolator_ctor();
-	}
-	[CompilerGenerated]
-	public void MyMethod()
-	{
-		if (AssemblyLoader.IsDefault())
-		{
-			object[] args = new object[0];
-			object obj = AssemblyLoader.InvokeMethod(this, "_isolator_1_MyMethod", args, BindingFlags.Instance | BindingFlags.NonPublic);
-		}
-		else
-		{
-			_isolator_1_MyMethod();
-		}
-	}
-	[CompilerGenerated]
-	private void _isolator_ctor()
-	{
-		Console.WriteLine("Constructor implementation");
-	}
-	[CompilerGenerated]
-	private void _isolator_1_MyMethod()
-	{
-		Console.WriteLine("Method implementation");
-	}
+  [CompilerGenerated]
+  public MyIsolatedClass()
+  {
+    if (AssemblyLoader.IsDefault())
+    {
+      object obj = AssemblyLoader.CreateInstance(this, new object[0]);
+      return;
+    }
+    _isolator_ctor();
+  }
+  [CompilerGenerated]
+  public void MyMethod()
+  {
+    if (AssemblyLoader.IsDefault())
+    {
+      object[] args = new object[0];
+      object obj = AssemblyLoader.InvokeMethod(this, "_isolator_1_MyMethod", args, BindingFlags.Instance | BindingFlags.NonPublic);
+    }
+    else
+    {
+      _isolator_1_MyMethod();
+    }
+  }
+  [CompilerGenerated]
+  private void _isolator_ctor()
+  {
+    Console.WriteLine("Constructor implementation");
+  }
+  [CompilerGenerated]
+  private void _isolator_1_MyMethod()
+  {
+    Console.WriteLine("Method implementation");
+  }
 }
 ```
 
@@ -119,7 +119,7 @@ Default FodyWeavers.xml:
 
 ```xml
 <Weavers>
-	<Isolator />
+  <Isolator />
 </Weavers>
 ```
 
@@ -148,11 +148,11 @@ As an element with items delimited by a newline.
 
 ```xml
 <Isolator>
-	<ClassNames>
-		App
-		AppDB
-		Command
-	</ClassNames>
+  <ClassNames>
+    App
+    AppDB
+    Command
+  </ClassNames>
 </Isolator>
 ```
 
@@ -172,11 +172,11 @@ As an element with items delimited by a newline.
 
 ```xml
 <Isolator>
-	<InterfaceNames>
-		IExternalApplication
-		IExternalDBApplication
-		IExternalCommand
-	</InterfaceNames>
+  <InterfaceNames>
+    IExternalApplication
+    IExternalDBApplication
+    IExternalCommand
+  </InterfaceNames>
 </Isolator>
 ```
 


### PR DESCRIPTION
### Features
- Support attribute `[Isolator]` to mark classes for isolation.
- Support attribute `[Isolator("ContextName")]` to isolate a specific context.
- Support `{name}` and `{guid}` placeholders in context name to be replaced by assembly name and assembly module guid.
- Support for isolating static classes and methods.
- Support clone method to isolate internally called methods. (Clone to a unique name start with `_isolate_`)
- Support multiple methods with ref/out parameters.
- Support configuration to isolate class or interface by name. (`ClassNames` and `InterfaceNames`)