### PR TITLE
Version 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 ### Updates
 - Update `ILTemplate` Collectible to `false`, disable `Unload` in `AssemblyLoadContext`.
+- Add `IsolatorExecute.Collectible` to update `Collectible` in the `ILTemplate`.
 
 ## [1.2.0] / 2026-04-29
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] / 2026-05-14
+### Features
+### Updates
+- Update `ILTemplate` Collectible to `false`, disable `Unload` in `AssemblyLoadContext`.
+
 ## [1.2.0] / 2026-04-29
 ### Features
 - Support build using `dotnet build`.
@@ -69,6 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `Configuration` to use `LoadAtModuleInit` and force `Attach` to create default `AssemblyLoadContext` at module init.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.3.0]: ../../compare/1.2.0...1.3.0
 [1.2.0]: ../../compare/1.1.0...1.2.0
 [1.1.0]: ../../compare/1.0.0...1.1.0
 [1.0.0]: ../../compare/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.3.0] / 2026-05-14
 ### Features
+- Support `Collectible` options to enable in the `AssemblyLoadContext` to allow unloading assemblies.
 ### Updates
 - Update `ILTemplate` Collectible to `false`, disable `Unload` in `AssemblyLoadContext`.
 - Add `IsolatorExecute.Collectible` to update `Collectible` in the `ILTemplate`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.0-rc</Version>
+    <Version>1.3.0</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.0-alpha</Version>
+    <Version>1.3.0-beta</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.3.0-alpha</Version>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.0-beta</Version>
+    <Version>1.3.0-rc</Version>
   </PropertyGroup>
 </Project>

--- a/Isolator.Fody.ConsoleApp/AssemblyLoadContextExtension.cs
+++ b/Isolator.Fody.ConsoleApp/AssemblyLoadContextExtension.cs
@@ -58,6 +58,21 @@ public static class AssemblyLoadContextExtension
     }
 
     /// <summary>
+    /// Determines whether the assembly of the specified object is loaded into a collectible context.
+    /// </summary>
+    /// <param name="assembly">The assembly to evaluate for its loading context. Cannot be null.</param>
+    /// <returns>true if the assembly is loaded into a collectible context; otherwise, false.</returns>
+    public static bool IsCollectible(this System.Reflection.Assembly assembly)
+    {
+#if NET
+        var context = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
+        return context.IsCollectible;
+#else
+        return false;
+#endif
+    }
+
+    /// <summary>
     /// Returns a context-specific integer identifier for the assembly of the specified object.
     /// </summary>
     /// <param name="value">The object whose assembly is used to determine the context number. Cannot be null.</param>

--- a/Isolator.Fody.ConsoleApp/ClassIsolator.cs
+++ b/Isolator.Fody.ConsoleApp/ClassIsolator.cs
@@ -26,4 +26,8 @@ public class ClassIsolator
     {
         return this.ToContextNumber();
     }
+    public bool IsCollectible()
+    {
+        return this.GetType().Assembly.IsCollectible();
+    }
 }

--- a/Isolator.Fody.ConsoleApp/Isolator.Fody.ConsoleApp.csproj
+++ b/Isolator.Fody.ConsoleApp/Isolator.Fody.ConsoleApp.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <WeaverConfiguration>
       <Weavers>
-        <Isolator InterfaceNames="IsolatorInterface" />
+        <Isolator InterfaceNames="IsolatorInterface" Collectible="false" />
       </Weavers>
     </WeaverConfiguration>
   </PropertyGroup>

--- a/Isolator.Fody.ConsoleApp/Program.cs
+++ b/Isolator.Fody.ConsoleApp/Program.cs
@@ -122,5 +122,8 @@ public class Program
 
         // Check ClassIsolator context is different from Class context
         Debug.Assert(instance.ExecuteContextNumber());
+
+        // Check if the context is collectible
+        Debug.Assert(instance.IsCollectible() == false);
     }
 }

--- a/Isolator.Fody/Configuration.cs
+++ b/Isolator.Fody/Configuration.cs
@@ -12,6 +12,9 @@ public class Configuration
         ContextName = null;
         ContextName = ReadString(config, nameof(ContextName));
 
+        Collectible = false;
+        Collectible = ReadBool(config, nameof(Collectible), Collectible);
+
         ClassNames = new List<string>();
         ClassNames = ReadList(config, nameof(ClassNames));
 
@@ -42,6 +45,7 @@ public class Configuration
     public List<string> ClassNames { get; }
     public List<string> InterfaceNames { get; }
     public string ContextName { get; }
+    public bool Collectible { get; }
 
     public static bool ReadBool(XElement config, string nodeName, bool @default)
     {

--- a/Isolator.Fody/Isolator.Fody.xcf
+++ b/Isolator.Fody/Isolator.Fody.xcf
@@ -27,6 +27,11 @@
       <xs:documentation>Name of the isolation context.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="Collectible" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Enable collectible in the 'IsolatorAssemblyLoadContext' template.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
   <xs:attribute name="EnableDebug" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>Force the template with the debug log enable.</xs:documentation>

--- a/Isolator.Fody/IsolatorExecute.Collectible.cs
+++ b/Isolator.Fody/IsolatorExecute.Collectible.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+public partial class ModuleWeaver
+{
+    private TypeDefinition isolatorAssemblyLoadContext;
+
+    private void UpdateCollectibleContext(bool enableCollectible = false)
+    {
+        if (_targetType is null)
+            return;
+
+        isolatorAssemblyLoadContext ??= _targetType.NestedTypes.SingleOrDefault(t => t.Name == "IsolatorAssemblyLoadContext");
+
+        var collectibleField = isolatorAssemblyLoadContext?.Fields.SingleOrDefault(f => f.Name == "Collectible");
+        if (collectibleField == null)
+            return;
+
+        // ensure field is static and not readonly so we can set its value
+        collectibleField.IsStatic = true;
+        collectibleField.IsInitOnly = false;
+
+        // If the field is not a literal, ensure the static constructor sets the desired default.
+        if (!collectibleField.IsLiteral)
+        {
+            WriteInfo($"Replace Collectible field with value: {enableCollectible} into IsolatorAssemblyLoadContext");
+
+            var module = isolatorAssemblyLoadContext.Module;
+            var cctor = isolatorAssemblyLoadContext.Methods.SingleOrDefault(m => m.IsConstructor && m.IsStatic);
+
+            if (cctor == null)
+            {
+                var methodAttrs = MethodAttributes.Private | MethodAttributes.Static | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName;
+                cctor = new MethodDefinition(".cctor", methodAttrs, module.TypeSystem.Void);
+                isolatorAssemblyLoadContext.Methods.Add(cctor);
+
+                var il = cctor.Body.GetILProcessor();
+                il.Append(Instruction.Create(enableCollectible ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
+                il.Append(Instruction.Create(OpCodes.Stsfld, collectibleField));
+                il.Append(Instruction.Create(OpCodes.Ret));
+            }
+            else
+            {
+                var il = cctor.Body.GetILProcessor();
+                var instructions = cctor.Body.Instructions.ToArray();
+                bool replaced = false;
+
+                for (int i = 0; i < instructions.Length; i++)
+                {
+                    var instr = instructions[i];
+                    if (instr.OpCode == OpCodes.Stsfld && instr.Operand is FieldReference fr && fr.Name == collectibleField.Name)
+                    {
+                        replaced = true;
+                        // Replace or insert the load boolean instruction before stsfld
+                        Instruction load = enableCollectible ? Instruction.Create(OpCodes.Ldc_I4_1) : Instruction.Create(OpCodes.Ldc_I4_0);
+                        var index = cctor.Body.Instructions.IndexOf(instr);
+                        if (index > 0)
+                        {
+                            var prev = cctor.Body.Instructions[index - 1];
+                            // If previous is a load of an int, replace it; otherwise insert
+                            if (prev.OpCode == OpCodes.Ldc_I4_0 || prev.OpCode == OpCodes.Ldc_I4_1 || prev.OpCode == OpCodes.Ldc_I4_2 || prev.OpCode == OpCodes.Ldc_I4 || prev.OpCode == OpCodes.Ldc_I4_S)
+                                il.Replace(prev, load);
+                            else
+                                il.InsertBefore(instr, load);
+                        }
+                        else
+                        {
+                            il.InsertBefore(instr, load);
+                        }
+
+                        // ensure operand references the field definition
+                        instr.Operand = collectibleField;
+                    }
+                }
+
+                if (!replaced)
+                {
+                    // no existing assignment found - insert at start (before first instruction) or append if empty
+                    var first = cctor.Body.Instructions.FirstOrDefault();
+                    var load = enableCollectible ? Instruction.Create(OpCodes.Ldc_I4_1) : Instruction.Create(OpCodes.Ldc_I4_0);
+                    if (first != null)
+                    {
+                        il.InsertBefore(first, load);
+                        il.InsertAfter(load, Instruction.Create(OpCodes.Stsfld, collectibleField));
+                    }
+                    else
+                    {
+                        il.Append(load);
+                        il.Append(Instruction.Create(OpCodes.Stsfld, collectibleField));
+                        il.Append(Instruction.Create(OpCodes.Ret));
+                    }
+                }
+            }
+        }
+
+    }
+
+}

--- a/Isolator.Fody/ModuleWeaver.cs
+++ b/Isolator.Fody/ModuleWeaver.cs
@@ -17,6 +17,7 @@ public sealed partial class ModuleWeaver : BaseModuleWeaver
         ImportAssemblyLoader(config.EnableDebug);
 
         FindContextNameMethod(config.ContextName);
+        UpdateCollectibleContext(config.Collectible);
         CallAttach(config.LoadAtModuleInit);
 
         IsolatorExecute();

--- a/Isolator.Template/ILTemplate.cs
+++ b/Isolator.Template/ILTemplate.cs
@@ -278,7 +278,7 @@ internal static class ILTemplate
             {
                 context.Unloading -= Unloading;
                 context.Unload();
-                Common.Log("[{0}] Context.Unload \t '{1}'", context.GetContextNumber(), context.Name);
+                Common.Log("[{0}] Context.Unload \t '{1}' \t {2}", context.GetContextNumber(), context.Name);
             }
             catch (Exception ex)
             {
@@ -316,9 +316,10 @@ internal static class ILTemplate
 
     internal class IsolatorAssemblyLoadContext : AssemblyLoadContext
     {
+        private static bool Collectible = false;
         private readonly List<AssemblyDependencyResolver> _resolvers = new List<AssemblyDependencyResolver>();
         private readonly List<string> _resolverPaths = new List<string>();
-        public IsolatorAssemblyLoadContext(string contextName, string assemblyPath) : base(contextName, isCollectible: true)
+        public IsolatorAssemblyLoadContext(string contextName, string assemblyPath) : base(contextName, isCollectible: Collectible)
         {
             // Cannot use 'AddResolver', not supported in the 'AssemblyLoaderImporter' in the 'Isolator.Fody' project.
             _resolvers.Add(new AssemblyDependencyResolver(assemblyPath));

--- a/README.md
+++ b/README.md
@@ -186,6 +186,15 @@ Or as an attribute with items delimited by a pipe `|`.
 <Isolator InterfaceNames='IExternalApplication|IExternalDBApplication|IExternalCommand' />
 ```
 
+### Collectible
+
+Indicates whether to enable the `Collectible` option in the `AssemblyLoadContext` to allow unloading assemblies. When enabled, the isolated assemblies can be unloaded from memory when they are no longer needed.
+
+*Defaults to `false`*
+```xml
+<Isolator Collectible='true' />
+```
+
 ## Debug Configuration Options
 
 These options are used for debugging purposes and can be enabled or disabled as needed.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Isolator.Fody 
 
-[![Visual Studio 2022](https://img.shields.io/badge/Visual%20Studio-2022-blue)](https://github.com/ricaun-io/Isolator.Fody)
+[![Visual Studio 2026](https://img.shields.io/badge/Visual%20Studio-2026-blue)](https://github.com/ricaun-io/Isolator.Fody)
 [![Nuke](https://img.shields.io/badge/Nuke-Build-blue)](https://nuke.build/)
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Build](https://github.com/ricaun-io/Isolator.Fody/actions/workflows/Build.yml/badge.svg)](https://github.com/ricaun-io/Isolator.Fody/actions)


### PR DESCRIPTION
### Features
- Support `Collectible` options to enable in the `AssemblyLoadContext` to allow unloading assemblies.
### Updates
- Update `ILTemplate` Collectible to `false`, disable `Unload` in `AssemblyLoadContext`.
- Add `IsolatorExecute.Collectible` to update `Collectible` in the `ILTemplate`.